### PR TITLE
Expand tilde

### DIFF
--- a/open_context_path.py
+++ b/open_context_path.py
@@ -121,6 +121,9 @@ class OpenContextPathCommand(sublime_plugin.TextCommand):
         dirs = view_settings.get("directories", [])
         dirs += settings.get("directories", [])
 
+        # expand ~ to the home directory
+        dirs = [os.path.expanduser(dir) for dir in dirs]
+
         # make all relative paths absolute by basing them on the project folder
         project = self.view.window().project_file_name()
         if project:

--- a/open_context_path.py
+++ b/open_context_path.py
@@ -266,6 +266,10 @@ class OpenContextPathCommand(sublime_plugin.TextCommand):
         if path in [".", ".."]:
             return None
 
+        # expand ~ to the user's home directory
+        if path.startswith("~"):
+            path = os.path.expanduser(path)
+
         if platform == "windows":
             # disable UNC paths on Windows
             if path.startswith("\\\\") or path.startswith("//"):


### PR DESCRIPTION
Paths starting with a ~ will now be correctly expanded to the user's
home directory before they are checked if they exist.

Relative paths will now also be found in search directories with a ~.

Fixes #2 